### PR TITLE
prague_cc: include <stddef.h> for size_t and switch to C++ headers

### DIFF
--- a/prague_cc.h
+++ b/prague_cc.h
@@ -1,7 +1,8 @@
 #ifndef PRAGUE_CC_H
 #define PRAGUE_CC_H
 
-#include <stdint.h>
+#include <cstddef>
+#include <cstdint>
 
 typedef uint64_t size_tp;    // size in Bytes
 typedef uint64_t window_tp;  // fractional window size in µBytes (to match time in µs, for easy Bytes/second rate calculations)


### PR DESCRIPTION
Add an explicit include of <stddef.h> in prague_cc.h to define size_t. This makes the module self-contained and prevents compilation errors when used as a standalone or wrapped target (e.g., Rust FFI).

Also replace C headers with their C++ equivalents.